### PR TITLE
Allow to override the token decode strategy

### DIFF
--- a/lib/devise/strategies/magic_link_authenticatable.rb
+++ b/lib/devise/strategies/magic_link_authenticatable.rb
@@ -21,7 +21,7 @@ module Devise
 
       def authenticate!
         begin
-          data = Devise::Passwordless::LoginToken.decode(self.token)
+          data = decode_passwordless_token
         rescue Devise::Passwordless::LoginToken::InvalidOrExpiredTokenError
           fail!(:magic_link_invalid)
           return
@@ -49,6 +49,10 @@ module Devise
       end
 
       private
+
+      def decode_passwordless_token
+        Devise::Passwordless::LoginToken.decode(self.token)
+      end
 
       # Sets the authentication hash and the token from params_auth_hash or http_auth_hash.
       def with_authentication_hash(auth_type, auth_values)


### PR DESCRIPTION
If you want to dynamically decide how long is the `expire_duration`, it's currently very hard.
Depending on some conditions, we might want to invoke `Devise::Passwordless::LoginToken.decode(self.token, 1.minute)` or `Devise::Passwordless::LoginToken.decode(self.token, 3.days)`.

This refactoring allows to override just the method `decode_passwordless_token` on the model in order to do that.