### PR TITLE
Add ability to add custom expiration to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ remember_me = true
 User.last.send_magic_link(remember_me)
 ```
 
+#### Generate links with custom expiration time
+
+You can generate magic link with a custom expiration time like so:
+
+```ruby
+expiration_time = 2.days.from_now # Or what ever your need
+token = Devise::Passwordless::LoginToken.encode(user, expires_at: expiration_time)
+remember_me = true # Or `false`, as per your need
+
+users_magic_link_url(
+  user: {
+    email: user.email,
+    token: token,
+    remember_me: remember_me
+  }
+)
+```
+
+This only generates the magic link. You will have to send an email manually.
+
 ## Customization
 
 Configuration options are stored in Devise's initializer at `config/initializers/devise.rb`:


### PR DESCRIPTION
Allow `expires_at` argument to `LoginToken.encode` and handle the same in `LoginToken.decode`.

The default configuration of `Devise.passwordless_login_within` is respected, when `expires_at` is `nil`.

Addresses: #18 

This is similar to #19 but less open.