### PR TITLE
Made sessions controller support turbo and devise 4.9

### DIFF
--- a/lib/generators/devise/passwordless/templates/sessions_controller.rb.erb
+++ b/lib/generators/devise/passwordless/templates/sessions_controller.rb.erb
@@ -6,13 +6,13 @@ class Devise::Passwordless::SessionsController < Devise::SessionsController
     self.resource = resource_class.find_by(email: create_params[:email])
     if self.resource
       resource.send_magic_link(create_params[:remember_me])
-      set_flash_message(:notice, :magic_link_sent, now: true)
+      set_flash_message(:notice, :magic_link_sent)
+      redirect_to(action: :new, status: redirect_status)
     else
-      set_flash_message(:alert, :not_found_in_database, now: true)
+      set_flash_message(:alert, :not_found_in_database)
+      self.resource = resource_class.new(create_params)
+      render :new, status: error_status
     end
-
-    self.resource = resource_class.new(create_params)
-    render :new
   end
 
   protected
@@ -29,6 +29,14 @@ class Devise::Passwordless::SessionsController < Devise::SessionsController
 
   def create_params
     resource_params.permit(:email, :remember_me)
+  end
+                                                                           
+  def redirect_status
+    Devise.respond_to?(:responder) ? Devise.responder.redirect_status : :found
+  end
+                                                                           
+  def error_status
+    Devise.respond_to?(:responder) ? Devise.responder.error_status : :ok
   end
 end
 <% end -%>


### PR DESCRIPTION
Devise 4.9 adds support for turbo, mainly by changing the response statuses in the sessions controller from 302 to 303 for success and 200 to 422 for errors.

    https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D

I've made this work in the same way, so that it works with turbo.

However, there is another issue caused by the way that devise passwordless re-renders the new template after signin. Turbo doesn't support re-rendering after form-submission, if you try it shows this error in the browser console:

    Error: Form responses must redirect to another location

To resolve that, I've changed the sessions controller to redirect to new after signing in rather than re-rendering.