### PR TITLE
Updated ruby versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,18 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.2
+          - 3.1
           - 3.0
           - 2.7
-          - 2.6
-          - 2.5
         gemfile:
           - Gemfile-rails-7
           - Gemfile-rails-6.1
           - Gemfile-rails-6.0
-        exclude:
-          # Rails 7 requires Ruby 2.7+
-          - ruby-version: 2.5
-            gemfile: Gemfile-rails-7
-          - ruby-version: 2.6
-            gemfile: Gemfile-rails-7
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Run gem tests


### PR DESCRIPTION
Github actions fails on ruby 2.5 because of a bundler error:

    The last version of bundler (~> 2) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
    bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.

Ruby 2.5 was EOL two years ago, so I've removed it and also Ruby 2.6 (which was EOL a year ago). I've also added ruby 3.1 and 3.2 (which were missing entirely)