### PR TITLE
Add API for encoding extra information in magic token

### DIFF
--- a/devise-passwordless.gemspec
+++ b/devise-passwordless.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_dependency "devise"
+  spec.add_development_dependency "timecop"
 end

--- a/lib/devise/strategies/magic_link_authenticatable.rb
+++ b/lib/devise/strategies/magic_link_authenticatable.rb
@@ -42,6 +42,7 @@ module Devise
         if validate(resource)
           remember_me(resource)
           resource.after_magic_link_authentication
+          env['warden.magic_link_extra'] = data['data'].delete('extra')
           success!(resource)
         else
           fail!(:magic_link_invalid)

--- a/spec/devise/passwordless/login_token_spec.rb
+++ b/spec/devise/passwordless/login_token_spec.rb
@@ -31,5 +31,26 @@ RSpec.describe Devise::Passwordless::LoginToken do
 
       expect(decrypted).to eq(expected_decrypt)
     end
+
+    it 'can encrypt and decrpt a resource with extra data supplied', freeze_time: Time.new(2023, 1, 1) do
+      token = described_class.encode(user, { foo: :bar })
+      decrypted = described_class.decode(token)
+
+      expected_decrypt =
+        {
+          "created_at" => 1672531200.0,
+          "data" => {
+            "resource" => {
+              "email" => "email@example.com",
+              "key" => 12345
+            },
+            "extra" => {
+              "foo" => "bar"
+            },
+          }
+        }
+
+      expect(decrypted).to eq(expected_decrypt)
+    end
   end
 end

--- a/spec/devise/passwordless/login_token_spec.rb
+++ b/spec/devise/passwordless/login_token_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Devise::Passwordless::LoginToken do
       Timecop.return
     end
 
-    it 'can encrypt and decrypt a resource', freeze_time: Time.new(2023, 1, 1) do
+    it 'can encrypt and decrypt a resource', freeze_time: Time.utc(2023, 1, 1) do
       token = described_class.encode(user)
       decrypted = described_class.decode(token)
 

--- a/spec/devise/passwordless/login_token_spec.rb
+++ b/spec/devise/passwordless/login_token_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Devise::Passwordless::LoginToken do
     let(:user) { double(:user, email: 'email@example.com', to_key: 12345) }
 
     before do
-      Timecop.freeze(Time.new(2023,1,1))
+      Timecop.freeze(Time.utc(2023, 1, 1))
 
       allow(described_class).to receive(:secret_key).and_return('sekret')
     end

--- a/spec/devise/passwordless/login_token_spec.rb
+++ b/spec/devise/passwordless/login_token_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Devise::Passwordless::LoginToken do
       expect(decrypted).to eq(expected_decrypt)
     end
 
-    it 'can encrypt and decrpt a resource with extra data supplied', freeze_time: Time.new(2023, 1, 1) do
+    it 'can encrypt and decrpt a resource with extra data supplied', freeze_time: Time.utc(2023, 1, 1) do
       token = described_class.encode(user, { foo: :bar })
       decrypted = described_class.decode(token)
 

--- a/spec/devise/passwordless/login_token_spec.rb
+++ b/spec/devise/passwordless/login_token_spec.rb
@@ -1,0 +1,35 @@
+require 'timecop'
+
+RSpec.describe Devise::Passwordless::LoginToken do
+  describe 'encryption and decryption' do
+    let(:user) { double(:user, email: 'email@example.com', to_key: 12345) }
+
+    before do
+      Timecop.freeze(Time.new(2023,1,1))
+
+      allow(described_class).to receive(:secret_key).and_return('sekret')
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it 'can encrypt and decrypt a resource', freeze_time: Time.new(2023, 1, 1) do
+      token = described_class.encode(user)
+      decrypted = described_class.decode(token)
+
+      expected_decrypt =
+        {
+          "created_at" => 1672531200.0,
+          "data" => {
+            "resource" => {
+              "email" => "email@example.com",
+              "key" => 12345
+            }
+          }
+        }
+
+      expect(decrypted).to eq(expected_decrypt)
+    end
+  end
+end


### PR DESCRIPTION
Hey there. We have some use cases where we want to store extra information in the token. i.e. an id of a resource the user can claim by clicking on the URL. I wanted to extend the API so that this information can be optionally passed along, and then subsequently made available somewhere on the request env upon successful decode.

Here is an example of using it, adapting the template generated controller code:

```ruby
class Devise::Passwordless::MagicLinksController < DeviseController
  prepend_before_action :require_no_authentication, only: :show
  prepend_before_action :allow_params_authentication!, only: :show
  prepend_before_action(only: [:show]) { request.env['devise.skip_timeout'] = true }

  def show
    self.resource = warden.authenticate!(auth_options)
    set_flash_message!(:notice, :signed_in)
    sign_in(resource_name, resource)
    yield resource if block_given?

    # everything up to here is the standard code. the following is new:
    extra = request.env['warden.magic_link_extra']
    process_magic_link_extra(extra) if extra
  end
```