### PR TITLE
Add Ruby 3.1 and 3.2 to CI.  Update checkout action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
-          - 3.0
+          - 3.2
+          - 3.1
+          - "3.0"
           - 2.7
           - 2.6
           - 2.5
@@ -26,10 +29,14 @@ jobs:
             gemfile: Gemfile-rails-7
           - ruby-version: 2.6
             gemfile: Gemfile-rails-7
+          - ruby-version: 3.1
+            gemfile: Gemfile-rails-6.0
+          - ruby-version: 3.2
+            gemfile: Gemfile-rails-6.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Run gem tests

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in devise-passwordless.gemspec
 gemspec
 
-gem "rake", "~> 10.0"
+gem "rake", "~> 13.0"
 
 group :test do
   gem "rspec", "~> 3.0"


### PR DESCRIPTION
Runs green on my fork.  Update to v3 for checkout action is required after May 18th, 2023.