### PR TITLE
fix validatable with `password_required?`

### DIFF
--- a/lib/devise/models/magic_link_authenticatable.rb
+++ b/lib/devise/models/magic_link_authenticatable.rb
@@ -6,7 +6,7 @@ module Devise
       extend ActiveSupport::Concern
 
       def password_required?
-        false
+        !persisted? || !password.nil? || !password_confirmation.nil? || !password.blank?
       end
 
       # Not having a password method breaks the :validatable module

--- a/lib/devise/passwordless/mailer.rb
+++ b/lib/devise/passwordless/mailer.rb
@@ -6,6 +6,7 @@ module Devise::Passwordless
     def magic_link(record, token, remember_me, opts = {})
       @token = token
       @remember_me = remember_me
+      @opts = opts
       devise_mail(record, :magic_link, opts)
     end
   end


### PR DESCRIPTION
`password_required?` now uses the same logic devise uses to check if password should be required which also does the validation checks.

Before the `current_user.update_with_password(password_params)` would not validate if the confirm was different from the password etc...

Also fixes:
```
App #⁠1: All users have a saved password; any user may login via email OR password (i.e. accept both methods)
App #⁠2: Only some users have a saved password; those users must login via password; everyone else logs in via email
```