### PR TITLE
Make session#create response work with Turbo Drive enabled

### DIFF
--- a/lib/generators/devise/passwordless/templates/sessions_controller.rb.erb
+++ b/lib/generators/devise/passwordless/templates/sessions_controller.rb.erb
@@ -3,16 +3,16 @@
 <% module_namespacing do -%>
 class Devise::Passwordless::SessionsController < Devise::SessionsController
   def create
-    self.resource = resource_class.find_by(email: create_params[:email])
-    if self.resource
-      resource.send_magic_link(create_params[:remember_me])
-      set_flash_message(:notice, :magic_link_sent, now: true)
+    self.resource = resource_class.new(create_params)
+    persisted_resource = resource_class.find_by(email: resource.email)
+    if persisted_resource
+      persisted_resource.send_magic_link(create_params[:remember_me])
+      set_flash_message(:notice, :magic_link_sent)
+      redirect_to root_path, status: :see_other
     else
       set_flash_message(:alert, :not_found_in_database, now: true)
+      render :new, status: :unprocessable_entity
     end
-
-    self.resource = resource_class.new(create_params)
-    render :new
   end
 
   protected


### PR DESCRIPTION
Turbo Drive expects a form response to have HTTP status 422 or be a 303 redirect. Therefore change the response of session#create:

- when no resource found, render :new with HTTP status 422
- when found, redirect to root_path with HTTP status 303

This assumes that the application has a root_path defined.

Previously, an application with Turbo would show the session#new form after submit unchanged and with this error in the javascript console:

    Error: Form responses must redirect to another location

![devise-passwordless-with-turbo](https://github.com/abevoelker/devise-passwordless/assets/11211/f71d2be6-22fd-4e0f-8c0b-86b4c62e3549)

----

It works for me :tm: in a new app with rails 7.0.7 and devise 4.9.2 with all the defaults enabled, including Turbo Drive. I suppose it should work with older apps, also without Turbo enabled, but I'm not 100% sure. Please let me know if you think that changes are necessary to make it backwards compatible, and I'll do my best to add them.

Regarding the changed UI flow after successful form submit: I think it's slightly better to not redisplay the form since the user has already successfully requested a magic link – prompting them again by showing the form could be a bit confusing. However relying on `root_path` to be defined is not ideal, but maybe acceptable for now?