### PR TITLE
Add upgrade note about having to remove mailer require

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,7 @@ to have a successful upgrade:
         to: "devise/passwordless/magic_links#show",
         as: "users_magic_link"
     ```
+* Remove `require 'devise/passwordless/mailer'` line from `config/initializers/devise.rb`
 
 * New Devise config value `passwordless_tokenizer` is required. Check README for
   an explanation of tokenizers.


### PR DESCRIPTION
Adds upgrade note about removing mailer require which was causing `uninitialized constant Devise::Mailer` error.

Fix #34