### PR TITLE
Fix account enumeration user account

### DIFF
--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -3,12 +3,10 @@ class Devise::Passwordless::SessionsController < Devise::SessionsController
     if (self.resource = resource_class.find_by(email: create_params[:email]))
       resource.send_magic_link(remember_me: create_params[:remember_me])
       set_flash_message!(:notice, :magic_link_sent)
-      redirect_to(after_magic_link_sent_path_for(resource), status: devise_redirect_status)
     else
-      self.resource = resource_class.new(create_params)
-      set_flash_message!(:alert, :not_found_in_database, now: true)
-      render :new, status: devise_error_status
-    end
+      set_flash_message!(:notice, :not_found_in_database)
+    end  
+    redirect_to(after_magic_link_sent_path_for(resource), status: devise_redirect_status)
   end
 
   protected

--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -5,8 +5,9 @@ class Devise::Passwordless::SessionsController < Devise::SessionsController
       set_flash_message!(:notice, :magic_link_sent)
     else
       set_flash_message!(:notice, :not_found_in_database)
-    end  
-    redirect_to(after_magic_link_sent_path_for(resource), status: devise_redirect_status)
+    end
+
+    redirect_to(after_magic_link_sent_path_for(resource_class), status: devise_redirect_status)
   end
 
   protected

--- a/spec/dummy_app_config/shared_source/all/config/locales/devise.en.yml
+++ b/spec/dummy_app_config/shared_source/all/config/locales/devise.en.yml
@@ -56,8 +56,8 @@ en:
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
     passwordless:
-      not_found_in_database: "Could not find a user for that email address"
-      magic_link_sent: "A login link has been sent to your email address. Please follow the link to log in to your account."
+      not_found_in_database: "If your account exists, you will receive an email with a login link. Please follow the link to log in to your account."
+      magic_link_sent: "If your account exists, you will receive an email with a login link. Please follow the link to log in to your account."
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"

--- a/spec/generators/templates/expected/devise.en.yml
+++ b/spec/generators/templates/expected/devise.en.yml
@@ -56,8 +56,8 @@ en:
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
     passwordless:
-      not_found_in_database: "Could not find a user for that email address"
-      magic_link_sent: "A login link has been sent to your email address. Please follow the link to log in to your account."
+      not_found_in_database: "If your account exists, you will receive an email with a login link. Please follow the link to log in to your account."
+      magic_link_sent: "If your account exists, you will receive an email with a login link. Please follow the link to log in to your account."
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"


### PR DESCRIPTION
Like the [Devise paranoid mode](https://github.com/heartcombo/devise/wiki/How-To:-Using-paranoid-mode,-avoid-user-enumeration-on-registerable): ensure the application returns consistent generic error messages in response to invalid account user email during the log in process.

[Following Testing for Account Enumeration and Guessable User Account](https://github.com/OWASP/www-project-web-security-testing-guide/blob/master/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.md).