### PR TITLE
Default config: add note about `passwordless_expire_old_tokens_on_sign_in` only working with `MessageEncryptorTokenizer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ config.passwordless_tokenizer = "SignedGlobalIDTokenizer"
 # generate your own secret value with e.g. `rake secret`
 # config.passwordless_secret_key = nil
 
-# When using the :trackable module, set to true to consider magic link tokens
-# generated before the user's current sign in time to be expired. In other words,
-# each time you sign in, all existing magic links will be considered invalid.
+# When using the :trackable module and MessageEncryptorTokenizer, set to true to 
+# consider magic link tokens generated before the user's current sign in time to 
+# be expired. In other words, each time you sign in, all existing magic links 
+# will be considered invalid.
 # config.passwordless_expire_old_tokens_on_sign_in = false
 ```
 

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -33,9 +33,9 @@ module Devise::Passwordless
           # generate your own secret value with e.g. `rake secret`
           # config.passwordless_secret_key = nil
 
-          # When using the :trackable module and MessageEncryptorTokenizer, set to true to 
-          # consider magic link tokens generated before the user's current sign in time to 
-          # be expired. In other words, each time you sign in, all existing magic links 
+          # When using the :trackable module and MessageEncryptorTokenizer, set to true to
+          # consider magic link tokens generated before the user's current sign in time to
+          # be expired. In other words, each time you sign in, all existing magic links
           # will be considered invalid.
           # config.passwordless_expire_old_tokens_on_sign_in = false
         CONFIG

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -33,9 +33,10 @@ module Devise::Passwordless
           # generate your own secret value with e.g. `rake secret`
           # config.passwordless_secret_key = nil
 
-          # When using the :trackable module, set to true to consider magic link tokens
-          # generated before the user's current sign in time to be expired. In other words,
-          # each time you sign in, all existing magic links will be considered invalid.
+          # When using the :trackable module and MessageEncryptorTokenizer, set to true to 
+          # consider magic link tokens generated before the user's current sign in time to 
+          # be expired. In other words, each time you sign in, all existing magic links 
+          # will be considered invalid.
           # config.passwordless_expire_old_tokens_on_sign_in = false
         CONFIG
         end

--- a/spec/dummy_app_config/shared_source/all/config/initializers/devise.rb
+++ b/spec/dummy_app_config/shared_source/all/config/initializers/devise.rb
@@ -330,8 +330,9 @@ Devise.setup do |config|
   # generate your own secret value with e.g. `rake secret`
   # config.passwordless_secret_key = nil
 
-  # When using the :trackable module, set to true to consider magic link tokens
-  # generated before the user's current sign in time to be expired. In other words,
-  # each time you sign in, all existing magic links will be considered invalid.
+  # When using the :trackable module and MessageEncryptorTokenizer, set to true to
+  # consider magic link tokens generated before the user's current sign in time to
+  # be expired. In other words, each time you sign in, all existing magic links
+  # will be considered invalid.
   # config.passwordless_expire_old_tokens_on_sign_in = false
 end

--- a/spec/generators/templates/expected/devise.rb
+++ b/spec/generators/templates/expected/devise.rb
@@ -328,8 +328,9 @@ Devise.setup do |config|
   # generate your own secret value with e.g. `rake secret`
   # config.passwordless_secret_key = nil
 
-  # When using the :trackable module, set to true to consider magic link tokens
-  # generated before the user's current sign in time to be expired. In other words,
-  # each time you sign in, all existing magic links will be considered invalid.
+  # When using the :trackable module and MessageEncryptorTokenizer, set to true to
+  # consider magic link tokens generated before the user's current sign in time to
+  # be expired. In other words, each time you sign in, all existing magic links
+  # will be considered invalid.
   # config.passwordless_expire_old_tokens_on_sign_in = false
 end


### PR DESCRIPTION
`passwordless_expire_old_tokens_on_sign_in` doesn't work for `SignedGlobalIDTokenizer` so added note that you have to be using `MessageEncryptorTokenizer`.