### PR TITLE
Set warden user before authenticating

### DIFF
--- a/app/controllers/devise/magic_links_controller.rb
+++ b/app/controllers/devise/magic_links_controller.rb
@@ -1,10 +1,13 @@
 class Devise::MagicLinksController < DeviseController
+  prepend_before_action :get_user, only: :show
   prepend_before_action :require_no_authentication, only: :show
   prepend_before_action :allow_params_authentication!, only: :show
   prepend_before_action(only: [:show]) { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/magic_link
   def show
+    warden.set_user(@user)
+    
     self.resource = warden.authenticate!(auth_options)
     set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, resource)
@@ -27,5 +30,9 @@ class Devise::MagicLinksController < DeviseController
 
   def create_params
     resource_params.permit(:email, :remember_me)
+  end
+
+  def get_user
+    @user = User.find_by(email: create_params[:email])
   end
 end


### PR DESCRIPTION
## What?
Set the warden user with `warden.set_user(@user)` before attempting to run `warden.authenticate!(auth_options)`.

## Why?
When trying to set up `devise-passwordless` on my app, I couldn't log in after clicking the login link.

After further investigation, I noticed that the problem was that the [auth_options](https://github.com/abevoelker/devise-passwordless/blob/904eb538df103513e09eda0240a2bfbac75678fb/app/controllers/devise/magic_links_controller.rb#L8) for my app didn't contain any information related to the user, other than the `:scope => :user`.

## Are there any side effects or bugs people should be aware of?
No. If `warden` fails to set a user, this means that there is no user with the given email to begin with, and the warden user would just be `nil`.

The `show` action would then proceed to attempt to authenticate just as always.
