### PR TITLE
 Do not fail when putting the gem into the Gemfile before devise itself

### DIFF
--- a/lib/devise/passwordless.rb
+++ b/lib/devise/passwordless.rb
@@ -1,3 +1,4 @@
+require "devise"
 require "devise/passwordless/version"
 require "devise/monkeypatch"
 require "devise/passwordless/rails" if defined?(Rails::Engine)

--- a/spec/dummy_app_config/Gemfile.append
+++ b/spec/dummy_app_config/Gemfile.append
@@ -6,5 +6,7 @@ group :development, :test do
   gem 'selenium-webdriver'
 end
 
-gem "devise"
+# We put devise-passwordless first, to test that adding after_magic_link_sent_path_for
+# to the controllers works in every order.
 gem "devise-passwordless", :path => "../../../"
+gem "devise"


### PR DESCRIPTION
* Just load devise in the gem first to ensure correct load order
* Put gems in the "wrong" order in the tests to get them to fail when this fix is not applied.

Fixes https://github.com/abevoelker/devise-passwordless/issues/50