### PR TITLE
Use case insensitive logins

### DIFF
--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Devise::Passwordless::SessionsController < Devise::SessionsController
   def create
-    if (self.resource = resource_class.find_by(email: create_params[:email]))
+    if (self.resource = resource_class.find_for_authentication(email: create_params[:email]))
       resource.send_magic_link(remember_me: create_params[:remember_me])
       if Devise.paranoid
         set_flash_message!(:notice, :magic_link_sent_paranoid)


### PR DESCRIPTION
The email provided currently by the user does not follow the Devise configuration for whether it should be lowercased or not. This adjusts it to use the [Devise helper method](https://github.com/heartcombo/devise/blob/bb18f4d3805be0bf5f45e21be39625c7cfd9c1d6/lib/devise/models/authenticatable.rb#L263) so that it will be lowercased it something like `config.case_insensitive_keys = [:email]` exists in the Devise config.

I'll gladly add some tests, but wanted to get this documented before I forgot about upstreaming the change.