### PR TITLE
Extract send_magic_link out to a method

### DIFF
--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -1,7 +1,7 @@
 class Devise::Passwordless::SessionsController < Devise::SessionsController
   def create
     if (self.resource = resource_class.find_for_authentication(email: create_params[:email]))
-      resource.send_magic_link(remember_me: create_params[:remember_me])
+      send_magic_link(resource)
       if Devise.paranoid
         set_flash_message!(:notice, :magic_link_sent_paranoid)
       else
@@ -22,6 +22,10 @@ class Devise::Passwordless::SessionsController < Devise::SessionsController
   end
 
   protected
+
+  def send_magic_link(resource)
+    resource.send_magic_link(remember_me: create_params[:remember_me])
+  end
 
   def translation_scope
     if action_name == "create"


### PR DESCRIPTION
I've extracted the code to send the magic link out to it's own method, which allows it to be overridden in other apps using this gem if they want to perform additional actions when the email is sent successfully. One of the strengths of devise is having overridable methods like this, so I feel that it's in-keeping with how other devise controllers work.

This can already be done using the `send_magic_link` method on the "user" model, but sometimes the logic you want to add doesn't make sense in the model layer. In my case I'd like to add additional tracking (similar to the trackable devise module) which requires access to the request object.