### PR TITLE
Allow Decoding of Subclasses in `decode` Method

### DIFF
--- a/lib/devise/passwordless/tokenizers/signed_global_id_tokenizer.rb
+++ b/lib/devise/passwordless/tokenizers/signed_global_id_tokenizer.rb
@@ -13,7 +13,7 @@ module Devise::Passwordless
     def self.decode(token, resource_class)
       resource = GlobalID::Locator.locate_signed(token, for: "login")
       raise ExpiredTokenError unless resource
-      raise InvalidTokenError if resource.class != resource_class
+      raise InvalidTokenError if resource.class <= resource_class
       [resource, {}]
     end
   end


### PR DESCRIPTION
I was struggling with an issue for the past days and I manage to fix it in my case, so I figure i'd do a PR so maybe it can help others. 

#### Summary

This PR modifies the `decode` method to allow children classes of the specified `resource_class` to be decoded. By changing the class comparison logic, this adjustment ensures that subclasses can be properly authenticated without throwing an `InvalidTokenError`.

#### Rationale
This change enhances the flexibility of the decode method by allowing subclasses to be decoded. For example:

```ruby
Copy code
class User
  devise :magic_link_authenticatable
end

class AnonymousUser < User
end

class Admin < User
end
```
In a controller, a token generated for a User can now be decoded into either an AnonymousUser or an Admin without raising an error:

```ruby
Copy code
# At this point, `user` could be an `AnonymousUser` or an `Admin`
token = user.encode_passwordless_token(expires_at: 2.hours.from_now)
```

` => User.decode_passwordless_token(token, User).first` # This works without throwing an InvalidTokenError


#### Benefits
- Supports more dynamic and hierarchical user models.
- Aligns with typical object-oriented inheritance principles, allowing subclasses to function as intended when decoding tokens.
- Backward Compatibility
- This change is backward-compatible for scenarios where no subclasses are involved, as the comparison using <= still ensures strict type matching if no inheritance is present.