### PR TITLE
Add callable support for passwordless secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ config.passwordless_tokenizer = "SignedGlobalIDTokenizer"
 # is nil, which means defer to Devise's `secret_key` config value. Changing this
 # key will render invalid all existing passwordless login tokens. You can
 # generate your own secret value with e.g. `rake secret`
+# Can also be a proc/lambda for dynamic resolution at runtime.
 # config.passwordless_secret_key = nil
 
 # When using the :trackable module and MessageEncryptorTokenizer, set to true to 

--- a/lib/devise/passwordless.rb
+++ b/lib/devise/passwordless.rb
@@ -19,12 +19,11 @@ module Devise
       @deprecator ||= ActiveSupport::Deprecation.new("1.1", "Devise-Passwordless")
     end
 
+    # Supports callable values (procs/lambdas) for dynamic resolution at runtime,
     def self.secret_key
-      if Devise.passwordless_secret_key.present?
-        Devise.passwordless_secret_key
-      else
-        Devise.secret_key
-      end
+      key = Devise.passwordless_secret_key
+      resolved = key.respond_to?(:call) ? key.call : key
+      resolved.presence || Devise.secret_key
     end
 
     FILTER_PARAMS_WARNING = "[DEVISE-PASSWORDLESS] We have detected that your Rails configuration does not " \

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -32,7 +32,7 @@ module Devise::Passwordless
             # is nil, which means defer to Devise's `secret_key` config value. Changing this
             # key will render invalid all existing passwordless login tokens. You can
             # generate your own secret value with e.g. `rake secret`
-            # Can also be a proc/lambda for dynamic resolution at runtime.
+            # Can also be a proc/lambda for dynamic resolution at runtime
             # config.passwordless_secret_key = nil
 
             # When using the :trackable module and MessageEncryptorTokenizer, set to true to
@@ -50,10 +50,10 @@ module Devise::Passwordless
             <p>Hello <%= @resource.email %>!</p>
 
             <p>You can login using the link below:</p>
-
+            
             <p><%= link_to "Log in to my account", magic_link_url(@resource, @scope_name => {email: @resource.email, token: @token, remember_me: @remember_me}) %></p>
-
-            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>
+            
+            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>          
           FILE
         end
       end

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -32,7 +32,7 @@ module Devise::Passwordless
             # is nil, which means defer to Devise's `secret_key` config value. Changing this
             # key will render invalid all existing passwordless login tokens. You can
             # generate your own secret value with e.g. `rake secret`
-            # Can also be a proc/lambda for dynamic resolution at runtime
+            # Can also be a proc/lambda for dynamic resolution at runtime.
             # config.passwordless_secret_key = nil
 
             # When using the :trackable module and MessageEncryptorTokenizer, set to true to
@@ -50,10 +50,10 @@ module Devise::Passwordless
             <p>Hello <%= @resource.email %>!</p>
 
             <p>You can login using the link below:</p>
-            
+
             <p><%= link_to "Log in to my account", magic_link_url(@resource, @scope_name => {email: @resource.email, token: @token, remember_me: @remember_me}) %></p>
-            
-            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>          
+
+            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>
           FILE
         end
       end

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -32,6 +32,7 @@ module Devise::Passwordless
             # is nil, which means defer to Devise's `secret_key` config value. Changing this
             # key will render invalid all existing passwordless login tokens. You can
             # generate your own secret value with e.g. `rake secret`
+            # Can also be a proc/lambda for dynamic resolution at runtime.
             # config.passwordless_secret_key = nil
 
             # When using the :trackable module and MessageEncryptorTokenizer, set to true to
@@ -49,10 +50,10 @@ module Devise::Passwordless
             <p>Hello <%= @resource.email %>!</p>
 
             <p>You can login using the link below:</p>
-            
+
             <p><%= link_to "Log in to my account", magic_link_url(@resource, @scope_name => {email: @resource.email, token: @token, remember_me: @remember_me}) %></p>
-            
-            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>          
+
+            <p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>
           FILE
         end
       end

--- a/spec/devise/passwordless_spec.rb
+++ b/spec/devise/passwordless_spec.rb
@@ -3,6 +3,25 @@ RSpec.describe Devise::Passwordless do
     expect(Devise::Passwordless::VERSION).not_to be nil
   end
 
+  describe ".secret_key" do
+    before { allow(Devise).to receive(:secret_key).and_return("default_secret") }
+
+    it "returns passwordless_secret_key when present" do
+      allow(Devise).to receive(:passwordless_secret_key).and_return("passwordless_secret")
+      expect(described_class.secret_key).to eq("passwordless_secret")
+    end
+
+    it "resolves callable passwordless_secret_key at runtime" do
+      allow(Devise).to receive(:passwordless_secret_key).and_return(-> { "dynamic_secret" })
+      expect(described_class.secret_key).to eq("dynamic_secret")
+    end
+
+    it "falls back to Devise.secret_key when passwordless_secret_key is blank" do
+      allow(Devise).to receive(:passwordless_secret_key).and_return(nil)
+      expect(described_class.secret_key).to eq("default_secret")
+    end
+  end
+
   context "check_filter_parameters" do
     let(:warn_msg) { Devise::Passwordless::FILTER_PARAMS_WARNING + "\n" }
 

--- a/spec/dummy_app_config/shared_source/all/config/initializers/devise.rb
+++ b/spec/dummy_app_config/shared_source/all/config/initializers/devise.rb
@@ -328,6 +328,7 @@ Devise.setup do |config|
   # is nil, which means defer to Devise's `secret_key` config value. Changing this
   # key will render invalid all existing passwordless login tokens. You can
   # generate your own secret value with e.g. `rake secret`
+  # Can also be a proc/lambda for dynamic resolution at runtime.
   # config.passwordless_secret_key = nil
 
   # When using the :trackable module and MessageEncryptorTokenizer, set to true to

--- a/spec/generators/templates/expected/devise.rb
+++ b/spec/generators/templates/expected/devise.rb
@@ -326,6 +326,7 @@ Devise.setup do |config|
   # is nil, which means defer to Devise's `secret_key` config value. Changing this
   # key will render invalid all existing passwordless login tokens. You can
   # generate your own secret value with e.g. `rake secret`
+  # Can also be a proc/lambda for dynamic resolution at runtime.
   # config.passwordless_secret_key = nil
 
   # When using the :trackable module and MessageEncryptorTokenizer, set to true to

--- a/spec/generators/templates/expected/magic_link.html.erb
+++ b/spec/generators/templates/expected/magic_link.html.erb
@@ -4,4 +4,4 @@
 
 <p><%= link_to "Log in to my account", magic_link_url(@resource, @scope_name => {email: @resource.email, token: @token, remember_me: @remember_me}) %></p>
 
-<p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>          
+<p>Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.</p>


### PR DESCRIPTION
**Why?**
Multi-tenant Rails applications often need to use different secret keys for different tenants/regions. Currently, passwordless_secret_key must be set to a static string at boot time, which doesn't work well for applications where the correct secret key is only known at request time. This change allows passwordless_secret_key to accept a callable (lambda/proc) that is evaluated on each access, enabling dynamic resolution of the secret key based on the current request context.

After this change, applications can configure devise-passwordless like this:
```
config.passwordless_secret_key = -> { CurrentTenant.passwordless_secret_key }
```

**What?**
- Updated Devise::Passwordless.secret_key to resolve callable values (lambdas/procs) before returning
- Added documentation explaining the callable support
-  Added tests for callable passwordless_secret_key configuration

**See Also**
[activerecord-tenanted ](https://github.com/basecamp/activerecord-tenanted)- This is the gem I am using that enables multi-tenant Rails applications, which is an example use case for this feature.


**The pipeline failures are unrelated to my change, I fixed one of them as it was just a whitespace issue.**