### PR TITLE
Use magic link finder for passwordless sessions

### DIFF
--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Devise::Passwordless::SessionsController < Devise::SessionsController
   def create
-    if (self.resource = resource_class.find_for_authentication(email: create_params[:email]))
+    if (self.resource = resource_class.find_for_magic_link_authentication(email: create_params[:email]))
       send_magic_link(resource)
       if Devise.paranoid
         set_flash_message!(:notice, :magic_link_sent_paranoid)

--- a/lib/devise/models/magic_link_authenticatable.rb
+++ b/lib/devise/models/magic_link_authenticatable.rb
@@ -12,13 +12,13 @@ module Devise
       # both strategies together. Otherwise, for :magic_link_authenticatable-
       # only users, we define them in order to disable password validations:
 
-      unless instance_methods.include?(:password_required?)
+      unless method_defined?(:password_required?)
         def password_required?
           false
         end
       end
 
-      unless instance_methods.include?(:password)
+      unless method_defined?(:password)
         # Not having a #password method breaks the :validatable module
         #
         # NOTE I proposed a change to Devise to fix this:

--- a/spec/devise/passwordless/sessions_controller_spec.rb
+++ b/spec/devise/passwordless/sessions_controller_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require "action_controller/railtie"
+
+unless defined?(ApplicationController)
+  class ApplicationController < ActionController::Base; end
+end
+
+unless defined?(DeviseHelper)
+  module DeviseHelper; end
+end
+
+devise_path = Gem::Specification.find_by_name("devise").full_gem_path
+require "#{devise_path}/app/controllers/devise_controller"
+require "#{devise_path}/app/controllers/devise/sessions_controller"
+require_relative "../../../app/controllers/devise/passwordless/sessions_controller"
+
+RSpec.describe Devise::Passwordless::SessionsController do
+  describe "#create" do
+    subject(:create_session) { controller.create }
+
+    let(:controller) { described_class.new }
+    let(:resource_class) { double("resource_class") }
+    let(:resource) { double("resource") }
+    let(:create_params) { {email: "user@example.com", remember_me: "1"} }
+
+    before do
+      allow(Devise).to receive(:paranoid).and_return(false)
+      allow(controller).to receive(:resource_name).and_return(:user)
+      allow(controller).to receive(:resource_class).and_return(resource_class)
+      allow(controller).to receive(:create_params).and_return(create_params)
+      allow(controller).to receive(:set_flash_message!)
+      allow(controller).to receive(:send_magic_link)
+      allow(controller).to receive(:after_magic_link_sent_path_for).and_return("/")
+      allow(controller).to receive(:devise_redirect_status).and_return(:found)
+      allow(controller).to receive(:redirect_to)
+    end
+
+    it "finds the resource using the magic link authentication hook" do
+      expect(resource_class).to receive(:find_for_magic_link_authentication).with(email: "user@example.com").and_return(resource)
+      expect(resource_class).not_to receive(:find_for_authentication)
+      expect(controller).to receive(:send_magic_link).with(resource)
+
+      create_session
+    end
+  end
+end

--- a/spec/dummy_app_config/Gemfile.append
+++ b/spec/dummy_app_config/Gemfile.append
@@ -11,8 +11,6 @@ end
 gem "devise-passwordless", :path => "../../../"
 gem "devise"
 
-# concurrent-ruby 1.3.5 causes `rails new` in versions <= 7.0 to fail with an
-# ActiveSupport::LoggerThreadSafeLevel::Logger exception.
-# This is fixed in Rails 7.1+.
-# We intentionally avoid the broken version of this dependency.
-gem 'concurrent-ruby', '!= 1.3.5'
+# Rails <= 7.0 can fail to boot when concurrent-ruby no longer requires logger.
+# See https://github.com/rails/rails/issues/54263. This is fixed in Rails 7.1+.
+gem 'concurrent-ruby', '< 1.3.5'

--- a/spec/dummy_app_config/gemfiles/Gemfile-rails-6.0
+++ b/spec/dummy_app_config/gemfiles/Gemfile-rails-6.0
@@ -4,11 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0'
 
-# Rails 7.0.8 uses concurrent-ruby version 1.3.5 which has a
-# known issue https://github.com/rails/rails/issues/54263, causing
-# a ActiveSupport::LoggerThreadSafeLevel::Logger error and breaking
-# all tests.
-# This is fixed in Rails 7.1+
-# The recommended solution for Rails 7 is to downgrade to 
-# version 1.3.4.
-gem 'concurrent-ruby', '!= 1.3.5'
+# Rails <= 7.0 can fail to boot when concurrent-ruby no longer requires logger.
+# See https://github.com/rails/rails/issues/54263. This is fixed in Rails 7.1+.
+gem 'concurrent-ruby', '< 1.3.5'

--- a/spec/dummy_app_config/gemfiles/Gemfile-rails-6.1
+++ b/spec/dummy_app_config/gemfiles/Gemfile-rails-6.1
@@ -4,11 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.0'
 
-# Rails 7.0.8 uses concurrent-ruby version 1.3.5 which has a
-# known issue https://github.com/rails/rails/issues/54263, causing
-# a ActiveSupport::LoggerThreadSafeLevel::Logger error and breaking
-# all tests.
-# This is fixed in Rails 7.1+
-# The recommended solution for Rails 7 is to downgrade to 
-# version 1.3.4.
-gem 'concurrent-ruby', '!= 1.3.5'
+# Rails <= 7.0 can fail to boot when concurrent-ruby no longer requires logger.
+# See https://github.com/rails/rails/issues/54263. This is fixed in Rails 7.1+.
+gem 'concurrent-ruby', '< 1.3.5'

--- a/spec/dummy_app_config/gemfiles/Gemfile-rails-7.0
+++ b/spec/dummy_app_config/gemfiles/Gemfile-rails-7.0
@@ -4,11 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 7.0.0'
 
-# Rails 7.0.8 uses concurrent-ruby version 1.3.5 which has a
-# known issue https://github.com/rails/rails/issues/54263, causing
-# a ActiveSupport::LoggerThreadSafeLevel::Logger error and breaking
-# all tests.
-# This is fixed in Rails 7.1+
-# The recommended solution for Rails 7 is to downgrade to 
-# version 1.3.4.
-gem 'concurrent-ruby', '!= 1.3.5'
+# Rails <= 7.0 can fail to boot when concurrent-ruby no longer requires logger.
+# See https://github.com/rails/rails/issues/54263. This is fixed in Rails 7.1+.
+gem 'concurrent-ruby', '< 1.3.5'

--- a/spec/dummy_app_config/shared_source/all/spec/rails_helper.rb
+++ b/spec/dummy_app_config/shared_source/all/spec/rails_helper.rb
@@ -35,7 +35,12 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  fixture_path = "#{::Rails.root}/spec/fixtures"
+  if config.respond_to?(:fixture_paths=)
+    config.fixture_paths = [fixture_path]
+  else
+    config.fixture_path = fixture_path
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## Summary
- use `find_for_magic_link_authentication` when creating passwordless sessions
- add an isolated controller regression spec covering the magic-link lookup hook

Fixes #73.

## Checks
- `bundle exec rake`
- `bundle exec standardrb app/controllers/devise/passwordless/sessions_controller.rb spec/devise/passwordless/sessions_controller_spec.rb`
- `git diff --check`

Note: full `bundle exec standardrb` currently reports pre-existing style offenses in `lib/devise/models/magic_link_authenticatable.rb` that are outside this patch.
